### PR TITLE
Detect librpm.so.9

### DIFF
--- a/lib/rpm/c.rb
+++ b/lib/rpm/c.rb
@@ -6,6 +6,7 @@ module RPM
 
     begin
       ffi_lib ['rpm',
+               'librpm.so.9',
                'librpm.so.8', # Tumbleweed
                'librpm.so.7', # fedora 23
                'librpm.so.3', 'librpm.so.2', 'librpm.so.1']


### PR DESCRIPTION
Add support for librpm.so.9 which is used by the EL9 distributions, e.g.: CentOS Stream 9, Rocky 9, RHEL9, etc...