### PR TITLE
Do not use headerNVR in Package.version

### DIFF
--- a/lib/rpm/package.rb
+++ b/lib/rpm/package.rb
@@ -261,15 +261,7 @@ module RPM
 
     # @return [Version] Version for this package
     def version
-      v_ptr = ::FFI::MemoryPointer.new(:pointer, 1)
-      r_ptr = ::FFI::MemoryPointer.new(:pointer, 1)
-
-      RPM::C.headerNVR(ptr, nil, v_ptr, r_ptr)
-      v = v_ptr.read_pointer.read_string
-      r = r_ptr.read_pointer.read_string
-      v_ptr.free
-      r_ptr.free
-      Version.new(v, r, self[:epoch])
+      Version.new(self[:version], self[:release], self[:epoch])
     end
 
     # String representation of the package: "name-version-release-arch"


### PR DESCRIPTION
It is no longer available with rpm >= 4.14

Copied commit from https://github.com/dmacvicar/ruby-rpm-ffi/pull/14 credit to @pterjan for the fix