### PR TITLE
Add a github action to release the gem

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,27 @@
+name: Push Gem to RubyGems
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: read
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      - uses: rubygems/release-gem@v1


### PR DESCRIPTION
Use `rubygems/release-gem@v1` to release the gem when a tag is pushed

Following:
* https://guides.rubygems.org/trusted-publishing/adding-a-publisher/
* https://guides.rubygems.org/trusted-publishing/releasing-gems/
* https://github.com/segiddins/rubygems-await/blob/main/.github/workflows/push_gem.yml