### PR TITLE
Use `rpmExpandMacros` on 4.14+

### DIFF
--- a/lib/rpm.rb
+++ b/lib/rpm.rb
@@ -41,7 +41,6 @@ module RPM
   # @param [String] name Name of the macro
   # @return [String] value of macro +name+
   def self.[](name)
-    val = ''
     buffer = ::FFI::MemoryPointer.new(:pointer, 1024)
     buffer.write_string("%{#{name}}")
     ret = RPM::C.expandMacros(nil, nil, buffer, 1024)

--- a/lib/rpm.rb
+++ b/lib/rpm.rb
@@ -41,10 +41,22 @@ module RPM
   # @param [String] name Name of the macro
   # @return [String] value of macro +name+
   def self.[](name)
-    buffer = ::FFI::MemoryPointer.new(:pointer, 1024)
-    buffer.write_string("%{#{name}}")
-    ret = RPM::C.expandMacros(nil, nil, buffer, 1024)
-    buffer.read_string
+    if C::rpm_version_code >= ((4 << 16) + (14 << 8) + (0 << 0))
+      obuf = ::FFI::MemoryPointer.new(:pointer)
+      sbuf = FFI::MemoryPointer.from_string("%{#{name}}")
+      ret = RPM::C.rpmExpandMacros(nil, sbuf, obuf, 0)
+      return if ret < 0
+
+      val = obuf.get_pointer(0)
+      val.read_string
+    else
+      buffer = ::FFI::MemoryPointer.new(:pointer, 1024)
+      buffer.write_string("%{#{name}}")
+      ret = RPM::C.expandMacros(nil, nil, buffer, 1024)
+      return if ret < 0
+
+      buffer.read_string
+    end
   end
 
   # Setup a macro

--- a/lib/rpm.rb
+++ b/lib/rpm.rb
@@ -45,7 +45,7 @@ module RPM
       obuf = ::FFI::MemoryPointer.new(:pointer)
       sbuf = FFI::MemoryPointer.from_string("%{#{name}}")
       ret = RPM::C.rpmExpandMacros(nil, sbuf, obuf, 0)
-      return if ret < 0
+      raise if ret < 0
 
       val = obuf.get_pointer(0)
       val.read_string
@@ -53,7 +53,7 @@ module RPM
       buffer = ::FFI::MemoryPointer.new(:pointer, 1024)
       buffer.write_string("%{#{name}}")
       ret = RPM::C.expandMacros(nil, nil, buffer, 1024)
-      return if ret < 0
+      raise if ret < 0
 
       buffer.read_string
     end

--- a/lib/rpm.rb
+++ b/lib/rpm.rb
@@ -42,13 +42,13 @@ module RPM
   # @return [String] value of macro +name+
   def self.[](name)
     if C::rpm_version_code >= ((4 << 16) + (14 << 8) + (0 << 0))
-      obuf = ::FFI::MemoryPointer.new(:pointer)
+      obuf = ::FFI::MemoryPointer.new(:pointer, 1)
       sbuf = FFI::MemoryPointer.from_string("%{#{name}}")
       ret = RPM::C.rpmExpandMacros(nil, sbuf, obuf, 0)
       raise if ret < 0
 
-      val = obuf.get_pointer(0)
-      val.read_string
+      val = obuf.read_pointer
+      val.nil? ? nil : val.read_string
     else
       buffer = ::FFI::MemoryPointer.new(:pointer, 1024)
       buffer.write_string("%{#{name}}")

--- a/lib/rpm/c/rpmmacro.rb
+++ b/lib/rpm/c/rpmmacro.rb
@@ -19,6 +19,7 @@ module RPM
     if rpm_version_code >= ((4 << 16) + (14 << 8) + (0 << 0))
       attach_function 'rpmPushMacro', [:pointer, :string, :string, :string, :int], :void
       attach_function 'rpmPopMacro', [:pointer, :string], :void
+      attach_function 'rpmExpandMacros', [:pointer, :pointer, :pointer, :int], :int
     else
       attach_function 'addMacro', [:pointer, :string, :string, :string, :int], :void
       attach_function 'delMacro', [:pointer, :string], :void

--- a/test/test_rpm.rb
+++ b/test/test_rpm.rb
@@ -25,12 +25,10 @@ class RPMRPMTests < Minitest::Test
   end
 
   def test_macro_read
-    skip("NoMethodError: undefined method `expandMacros' for module RPM::C")
     assert_equal '/usr', RPM['_usr']
   end
 
   def test_macro_write
-    skip("NoMethodError: undefined method `expandMacros' for module RPM::C")
     RPM['hoge'] = 'hoge'
     assert_equal(RPM['hoge'], 'hoge')
   end

--- a/test/test_transaction.rb
+++ b/test/test_transaction.rb
@@ -57,6 +57,8 @@ class RPMTransactionTests < Minitest::Test
   end
 
   def test_test_flag_install
+    skip("hanging")
+
     filename = 'simple-1.0-0.i586.rpm'
     pkg = RPM::Package.open(fixture(filename))
 
@@ -77,6 +79,8 @@ class RPMTransactionTests < Minitest::Test
 
   def test_install_and_remove
     pkg = RPM::Package.open(fixture(PACKAGE_FILENAME))
+
+    skip("hanging")
 
     Dir.mktmpdir do |dir|
       RPM.transaction(dir) do |t|

--- a/test/test_transaction.rb
+++ b/test/test_transaction.rb
@@ -57,8 +57,6 @@ class RPMTransactionTests < Minitest::Test
   end
 
   def test_test_flag_install
-    skip("NoMethodError: undefined method `expandMacros' for RPM::C:Module")
-
     filename = 'simple-1.0-0.i586.rpm'
     pkg = RPM::Package.open(fixture(filename))
 
@@ -79,8 +77,6 @@ class RPMTransactionTests < Minitest::Test
 
   def test_install_and_remove
     pkg = RPM::Package.open(fixture(PACKAGE_FILENAME))
-
-    skip("NoMethodError: undefined method `expandMacros' for RPM::C:Module")
 
     Dir.mktmpdir do |dir|
       RPM.transaction(dir) do |t|


### PR DESCRIPTION
http://ftp.rpm.org/api/4.14.0/group__rpmmacro.html#ga8043f4f9a4cee1b8641e4a2ef1a717bb

This was deprecated in 4.13.0 http://ftp.rpm.org/api/4.13.0/rpmmacro_8h.html#a4bf96cf2d6c9d0375b95d852ad311f75 and removed in 4.14.0